### PR TITLE
Fix HTML file path handling in Streamlit app

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,6 @@
 import streamlit as st
 import streamlit.components.v1 as components
+from pathlib import Path
 
 # --- CONFIGURACIÓN DE LA PÁGINA ---
 # Esto debe ser lo primero que se ejecute en tu script.
@@ -12,10 +13,13 @@ st.set_page_config(
 
 # --- CARGAR EL HTML ---
 # Abre el archivo HTML que creamos y guárdalo en una variable.
-with open('index.html', 'r', encoding='utf-8') as f:
+# Usa rutas relativas basadas en la ubicación de este script para evitar errores
+# cuando se ejecuta desde otros directorios.
+html_path = Path(__file__).resolve().parent / "index.html"
+with open(html_path, "r", encoding="utf-8") as f:
     html_code = f.read()
 
 # --- MOSTRAR EL HTML EN STREAMLIT ---
-# Usa st.components.v1.html para renderizar tu código HTML.
+# Renderiza el código HTML dentro de la aplicación.
 # Le damos un alto generoso para que ocupe buena parte de la pantalla y activamos el scroll.
-st.components.v1.html(html_code, height=1200, scrolling=True)
+components.html(html_code, height=1200, scrolling=True)


### PR DESCRIPTION
## Summary
- ensure `index.html` is loaded relative to `app.py`'s location
- simplify Streamlit component usage by calling `components.html`

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68c6e3e2f2588330b9699dce1e5f3533